### PR TITLE
index,test: support browserify

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,1 @@
-module.exports = process.env.type_COV
-  ? require('./lib-cov/type')
-  : require('./lib/type');
+module.exports = require('./lib/type');

--- a/test/bootstrap/index.js
+++ b/test/bootstrap/index.js
@@ -1,2 +1,4 @@
 global.assert = require('simple-assert');
-global.type = require('../..');
+global.type = process.env.type_COV
+  ? require('../../lib-cov/type')
+  : require('../../lib/type');


### PR DESCRIPTION
Move the conditional require from /index.js to /test/bootstrap/index.js.

This allows browserify to process the module and makes the code more compliant
with upcoming ES6 modules.

Closes #1.
