### PR TITLE
Included support for ECMA6 types

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,77 +30,109 @@ var type = require('type-detect');
 #### array
 
 ```js
-assert('array' === type([]));
-assert('array' === type(new Array()));
+assert(type([]) === 'array');
+assert(type(new Array()) === 'array');
 ```
 
 #### regexp
 
 ```js
-assert('regexp' === type(/a-z/gi));
-assert('regexp' === type(new RegExp('a-z')));
+assert(type(/a-z/gi) === 'regexp');
+assert(type(new RegExp('a-z')) === 'regexp');
 ```
 
 #### function
 
 ```js
-assert('function' === type(function () {}));
+assert(type(function () {}) === 'function');
 ```
 
 #### arguments
 
 ```js
 (function () {
-  assert('arguments' === type(arguments));
+  assert(type(arguments) === 'arguments');
 })();
 ```
 
 #### date
 
 ```js
-assert('date' === type(new Date));
+assert(type(new Date) === 'date');
 ```
 
 #### number
 
 ```js
-assert('number' === type(1));
-assert('number' === type(1.234));
-assert('number' === type(-1));
-assert('number' === type(-1.234));
-assert('number' === type(Infinity));
-assert('number' === type(NaN));
+assert(type(1) === 'number');
+assert(type(1.234) === 'number');
+assert(type(-1) === 'number');
+assert(type(-1.234) === 'number');
+assert(type(Infinity) === 'number');
+assert(type(NaN) === 'number');
 ```
 
 #### string
 
 ```js
-assert('string' === type('hello world'));
+assert(type('hello world') === 'string');
 ```
 
 #### null
 
 ```js
-assert('null' === type(null));
-assert('null' !== type(undefined));
+assert(type(null) === 'null');
+assert(type(undefined) !== 'null');
 ```
 
 #### undefined
 
 ```js
-assert('undefined' === type(undefined));
-assert('undefined' !== type(null));
+assert(type(undefined) === 'undefined');
+assert(type(null) !== 'undefined');
 ```
 
 #### object
 
 ```js
 var Noop = function () {};
-assert('object' === type({}));
-assert('object' !== type(Noop));
-assert('object' === type(new Noop));
-assert('object' === type(new Object));
-assert('object' === type(new String('hello')));
+assert(type({}) === 'object');
+assert(type(Noop) !== 'object');
+assert(type(new Noop) === 'object');
+assert(type(new Object) === 'object');
+assert(type(new String('hello')) === 'object');
+```
+
+#### ECMA6 Types
+
+Supports all ECMA6 Types:
+
+```js
+assert(type(new Map() === 'map');
+assert(type(new WeakMap()) === 'weakmap');
+assert(type(new Set()) === 'set');
+assert(type(new WeakSet()) === 'weakset');
+assert(type(Symbol()) === 'symbol');
+assert(type(new Promise(callback) === 'promise');
+assert(type(new Int8Array()) === 'int8array');
+assert(type(new Uint8Array()) === 'uint8array');
+assert(type(new UInt8ClampedArray()) === 'uint8clampedarray');
+assert(type(new Int16Array()) === 'int16array');
+assert(type(new Uint16Array()) === 'uint16array');
+assert(type(new Int32Array()) === 'int32array');
+assert(type(new UInt32Array()) === 'uint32array');
+assert(type(new Float32Array()) === 'float32array');
+assert(type(new Float64Array()) === 'float64array');
+assert(type(new ArrayBuffer()) === 'arraybuffer');
+assert(type(new DataView(arrayBuffer)) === 'dataview');
+```
+
+If you use `Symbol.toStringTag` to change an Objects return value of the `toString()` Method, `type()` will return this value, e.g:
+
+```js
+var myObject = {};
+myObject[Symbol.toStringTag] = 'myCustomType';
+assert(type(myObject) === 'myCustomType');
 ```
 
 ### Library
@@ -119,7 +151,7 @@ var lib = new type.Library;
 Expose replacement `typeof` detection to the library.
 
 ```js
-if ('string' === lib.of('hello world')) {
+if (lib.of('hello world') === 'string') {
   // ...
 }
 ```
@@ -142,9 +174,9 @@ lib.define('int', /^[0-9]+$/);
 
 ```js
 lib.define('bln', function (obj) {
-  if ('boolean' === lib.of(obj)) return true;
+  if (lib.of(obj) === 'boolean') return true;
   var blns = [ 'yes', 'no', 'true', 'false', 1, 0 ];
-  if ('string' === lib.of(obj)) obj = obj.toLowerCase();
+  if (lib.of(obj) === 'string') obj = obj.toLowerCase();
   return !! ~blns.indexOf(obj);
 });
 ```

--- a/lib/type.js
+++ b/lib/type.js
@@ -25,7 +25,8 @@ var objectTypeRegexp = /^\[object (.*)\]$/;
 
 function getType(obj) {
   var type = Object.prototype.toString.call(obj).match(objectTypeRegexp)[1].toLowerCase();
-  if(type === 'string' && typeof obj === 'object') return 'object'; // Let "new String('')" return 'object'
+  if (type === 'string' && typeof obj === 'object') return 'object'; // Let "new String('')" return 'object'
+  if (typeof Promise === 'function' && obj instanceof Promise) return 'promise'; // Without support of @@toStringTag, Promise has type 'object'
   if (obj === null) return 'null'; // PhantomJS has type "DOMWindow" for null
   if (obj === undefined) return 'undefined'; // PhantomJS has type "DOMWindow" for undefined
   return type;

--- a/lib/type.js
+++ b/lib/type.js
@@ -25,10 +25,14 @@ var objectTypeRegexp = /^\[object (.*)\]$/;
 
 function getType(obj) {
   var type = Object.prototype.toString.call(obj).match(objectTypeRegexp)[1].toLowerCase();
-  if (type === 'string' && typeof obj === 'object') return 'object'; // Let "new String('')" return 'object'
-  if (typeof Promise === 'function' && obj instanceof Promise) return 'promise'; // Without support of @@toStringTag, Promise has type 'object'
-  if (obj === null) return 'null'; // PhantomJS has type "DOMWindow" for null
-  if (obj === undefined) return 'undefined'; // PhantomJS has type "DOMWindow" for undefined
+  // Let "new String('')" return 'object'
+  if (type === 'string' && typeof obj === 'object') return 'object';
+  // Without support of @@toStringTag, Promise has type 'object'
+  if (typeof Promise === 'function' && obj instanceof Promise) return 'promise';
+  // PhantomJS has type "DOMWindow" for null
+  if (obj === null) return 'null';
+  // PhantomJS has type "DOMWindow" for undefined
+  if (obj === undefined) return 'undefined';
   return type;
 }
 

--- a/lib/type.js
+++ b/lib/type.js
@@ -10,18 +10,6 @@
 
 var exports = module.exports = getType;
 
-/*!
- * Detectable javascript natives
- */
-
-var natives = {
-    '[object Array]': 'array'
-  , '[object RegExp]': 'regexp'
-  , '[object Function]': 'function'
-  , '[object Arguments]': 'arguments'
-  , '[object Date]': 'date'
-};
-
 /**
  * ### typeOf (obj)
  *
@@ -33,14 +21,14 @@ var natives = {
  * @return {String} object type
  * @api public
  */
+var objectTypeRegexp = /^\[object (.*)\]$/;
 
 function getType(obj) {
-  var str = Object.prototype.toString.call(obj);
-  if (natives[str]) return natives[str];
-  if (obj === null) return 'null';
-  if (obj === undefined) return 'undefined';
-  if (obj === Object(obj)) return 'object';
-  return typeof obj;
+  var type = Object.prototype.toString.call(obj).match(objectTypeRegexp)[1].toLowerCase();
+  if(type === 'string' && typeof obj === 'object') return 'object'; // Let "new String('')" return 'object'
+  if (obj === null) return 'null'; // PhantomJS has type "DOMWindow" for null
+  if (obj === undefined) return 'undefined'; // PhantomJS has type "DOMWindow" for undefined
+  return type;
 }
 
 exports.Library = Library;

--- a/test/type.js
+++ b/test/type.js
@@ -182,6 +182,13 @@ describe('type(obj)', function () {
       });
     }
 
+    if (typeof Promise === 'function') {
+      it('promise', function () {
+        var noop = function () {};
+        assert('promise' === type(new Promise(noop)));
+      });
+    }
+
     if (typeof Int8Array === 'function') {
       it('int8array', function () {
         assert('int8array' === type(new Int8Array()));
@@ -238,14 +245,14 @@ describe('type(obj)', function () {
 
     if (typeof DataView === 'function') {
       it('dataview', function () {
-        var arrayBuffer = new ArrayBuffer();
+        var arrayBuffer = new ArrayBuffer(1);
         assert('dataview' === type(new DataView(arrayBuffer)));
       });
     }
 
     if (typeof ArrayBuffer === 'function') {
       it('arraybuffer', function () {
-        assert('arraybuffer' === type(new ArrayBuffer()));
+        assert('arraybuffer' === type(new ArrayBuffer(1)));
       });
     }
   })

--- a/test/type.js
+++ b/test/type.js
@@ -156,30 +156,40 @@ describe('type(obj)', function () {
       it('map', function () {
         assert('map' === type(new Map()));
       });
+    } else {
+      it('map');
     }
 
     if (typeof WeakMap === 'function') {
       it('weakmap', function () {
         assert('weakmap' === type(new WeakMap()));
       });
+    } else {
+      it('weakmap')
     }
 
     if (typeof Set === 'function') {
       it('set', function () {
         assert('set' === type(new Set()));
       });
+    } else {
+      it('set')
     }
 
     if (typeof WeakSet === 'function') {
       it('weakset', function () {
         assert('weakset' === type(new WeakSet()));
       });
+    } else {
+      it('weakset')
     }
 
     if (typeof Symbol === 'function') {
       it('symbol', function () {
         assert('symbol' === type(Symbol()));
       });
+    } else {
+      it('symbol')
     }
 
     if (typeof Promise === 'function') {
@@ -187,60 +197,80 @@ describe('type(obj)', function () {
         var noop = function () {};
         assert('promise' === type(new Promise(noop)));
       });
+    } else {
+      it('promise')
     }
 
     if (typeof Int8Array === 'function') {
       it('int8array', function () {
         assert('int8array' === type(new Int8Array()));
       });
+    } else {
+      it('int8array')
     }
 
     if (typeof Uint8Array === 'function') {
       it('uint8array', function () {
         assert('uint8array' === type(new Uint8Array()));
       });
+    } else {
+      it('uint8array')
     }
 
     if (typeof Uint8ClampedArray === 'function') {
       it('uint8clampedarray', function () {
         assert('uint8clampedarray' === type(new Uint8ClampedArray()));
       });
+    } else {
+      it('uint8clampedarray')
     }
 
     if (typeof Int16Array === 'function') {
       it('int16array', function () {
         assert('int16array' === type(new Int16Array()));
       });
+    } else {
+      it('int16array')
     }
 
     if (typeof Uint16Array === 'function') {
       it('uint16array', function () {
         assert('uint16array' === type(new Uint16Array()));
       });
+    } else {
+      it('uint16array')
     }
 
     if (typeof Int32Array === 'function') {
       it('int32array', function () {
         assert('int32array' === type(new Int32Array()));
       });
+    } else {
+      it('int32array')
     }
 
     if (typeof Uint32Array === 'function') {
       it('uint32array', function () {
         assert('uint32array' === type(new Uint32Array()));
       });
+    } else {
+      it('uint32array')
     }
 
     if (typeof Float32Array === 'function') {
       it('float32array', function () {
         assert('float32array' === type(new Float32Array()));
       });
+    } else {
+      it('float32array')
     }
 
     if (typeof Float64Array === 'function') {
       it('float64array', function () {
         assert('float64array' === type(new Float64Array()));
       });
+    } else {
+      it('float64array')
     }
 
     if (typeof DataView === 'function') {
@@ -248,12 +278,17 @@ describe('type(obj)', function () {
         var arrayBuffer = new ArrayBuffer(1);
         assert('dataview' === type(new DataView(arrayBuffer)));
       });
+    } else {
+      it('dataview')
     }
 
     if (typeof ArrayBuffer === 'function') {
       it('arraybuffer', function () {
         assert('arraybuffer' === type(new ArrayBuffer(1)));
       });
+    } else {
+      it('arraybuffer')
     }
-  })
+
+  });
 });

--- a/test/type.js
+++ b/test/type.js
@@ -54,4 +54,199 @@ describe('type(obj)', function () {
     assert('object' === type(new Object));
     assert('object' === type(new String('hello')));
   });
+
+  describe('New ECMA6 Types Stubbed', function () {
+    var originalObjectToString = Object.prototype.toString;
+
+    function stubObjectToStringOnce(staticValue) {
+      Object.prototype.toString = function () {
+        Object.prototype.toString = originalObjectToString;
+        return staticValue;
+      };
+    }
+
+    it('map', function () {
+      stubObjectToStringOnce('[object Map]');
+      assert('map' === type({}));
+    });
+
+    it('weakmap', function () {
+      stubObjectToStringOnce('[object WeakMap]');
+      assert('weakmap' === type({}));
+    });
+
+    it('set', function () {
+      stubObjectToStringOnce('[object Set]');
+      assert('set' === type({}));
+    });
+
+    it('weakset', function () {
+      stubObjectToStringOnce('[object WeakSet]');
+      assert('weakset' === type({}));
+    });
+
+    it('symbol', function () {
+      stubObjectToStringOnce('[object Symbol]');
+      assert('symbol' === type({}));
+    });
+
+    it('promise', function () {
+      stubObjectToStringOnce('[object Promise]');
+      assert('promise' === type({}));
+    });
+
+    it('int8array', function () {
+      stubObjectToStringOnce('[object Int8Array]');
+      assert('int8array' === type({}));
+    });
+
+    it('uint8array', function () {
+      stubObjectToStringOnce('[object Uint8Array]');
+      assert('uint8array' === type({}));
+    });
+
+    it('uint8clampedarray', function () {
+      stubObjectToStringOnce('[object Uint8ClampedArray]');
+      assert('uint8clampedarray' === type({}));
+    });
+
+    it('int16array', function () {
+      stubObjectToStringOnce('[object Int16Array]');
+      assert('int16array' === type({}));
+    });
+
+    it('uint16array', function () {
+      stubObjectToStringOnce('[object Uint16Array]');
+      assert('uint16array' === type({}));
+    });
+
+    it('int32array', function () {
+      stubObjectToStringOnce('[object Int32Array]');
+      assert('int32array' === type({}));
+    });
+
+    it('uint32array', function () {
+      stubObjectToStringOnce('[object Uint32Array]');
+      assert('uint32array' === type({}));
+    });
+
+    it('float32array', function () {
+      stubObjectToStringOnce('[object Float32Array]');
+      assert('float32array' === type({}));
+    });
+
+    it('float64array', function () {
+      stubObjectToStringOnce('[object Float64Array]');
+      assert('float64array' === type({}));
+    });
+
+    it('dataview', function () {
+      stubObjectToStringOnce('[object DataView]');
+      assert('dataview' === type({}));
+    });
+
+    it('arraybuffer', function () {
+      stubObjectToStringOnce('[object ArrayBuffer]');
+      assert('arraybuffer' === type({}));
+    });
+  });
+
+  describe('New ECMA6 Types Conditional', function () {
+    if (typeof Map === 'function') {
+      it('map', function () {
+        assert('map' === type(new Map()));
+      });
+    }
+
+    if (typeof WeakMap === 'function') {
+      it('weakmap', function () {
+        assert('weakmap' === type(new WeakMap()));
+      });
+    }
+
+    if (typeof Set === 'function') {
+      it('set', function () {
+        assert('set' === type(new Set()));
+      });
+    }
+
+    if (typeof WeakSet === 'function') {
+      it('weakset', function () {
+        assert('weakset' === type(new WeakSet()));
+      });
+    }
+
+    if (typeof Symbol === 'function') {
+      it('symbol', function () {
+        assert('symbol' === type(Symbol()));
+      });
+    }
+
+    if (typeof Int8Array === 'function') {
+      it('int8array', function () {
+        assert('int8array' === type(new Int8Array()));
+      });
+    }
+
+    if (typeof Uint8Array === 'function') {
+      it('uint8array', function () {
+        assert('uint8array' === type(new Uint8Array()));
+      });
+    }
+
+    if (typeof Uint8ClampedArray === 'function') {
+      it('uint8clampedarray', function () {
+        assert('uint8clampedarray' === type(new Uint8ClampedArray()));
+      });
+    }
+
+    if (typeof Int16Array === 'function') {
+      it('int16array', function () {
+        assert('int16array' === type(new Int16Array()));
+      });
+    }
+
+    if (typeof Uint16Array === 'function') {
+      it('uint16array', function () {
+        assert('uint16array' === type(new Uint16Array()));
+      });
+    }
+
+    if (typeof Int32Array === 'function') {
+      it('int32array', function () {
+        assert('int32array' === type(new Int32Array()));
+      });
+    }
+
+    if (typeof Uint32Array === 'function') {
+      it('uint32array', function () {
+        assert('uint32array' === type(new Uint32Array()));
+      });
+    }
+
+    if (typeof Float32Array === 'function') {
+      it('float32array', function () {
+        assert('float32array' === type(new Float32Array()));
+      });
+    }
+
+    if (typeof Float64Array === 'function') {
+      it('float64array', function () {
+        assert('float64array' === type(new Float64Array()));
+      });
+    }
+
+    if (typeof DataView === 'function') {
+      it('dataview', function () {
+        var arrayBuffer = new ArrayBuffer();
+        assert('dataview' === type(new DataView(arrayBuffer)));
+      });
+    }
+
+    if (typeof ArrayBuffer === 'function') {
+      it('arraybuffer', function () {
+        assert('arraybuffer' === type(new ArrayBuffer()));
+      });
+    }
+  })
 });


### PR DESCRIPTION
* Changed the **getType()** Method to be more generic and support ECMA6 as well as custom types
* Deleted NativeTypes as no longer needed
* Added (fake) Tests for ECMA6 types (by stubbing Object.prototype.toString)
* Updated Readme.md with ECMA6 Types 

I'm not sure if the way of treating a change to Object[Symbol.toStringTag] by returnig the given value is the right one - maybe it should actually return just 'object'. On the other hand: Whoever uses this probably knows what he is doing and won't have a problem with it.