### PR TITLE
"new String()" as 'string' instead of 'object'

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,12 +70,14 @@ assert(type(-1) === 'number');
 assert(type(-1.234) === 'number');
 assert(type(Infinity) === 'number');
 assert(type(NaN) === 'number');
+assert(type(new Number(1)) === 'number');
 ```
 
 #### string
 
 ```js
 assert(type('hello world') === 'string');
+assert(type(new String('hello')) === 'object');
 ```
 
 #### null
@@ -100,7 +102,6 @@ assert(type({}) === 'object');
 assert(type(Noop) !== 'object');
 assert(type(new Noop) === 'object');
 assert(type(new Object) === 'object');
-assert(type(new String('hello')) === 'object');
 ```
 
 #### ECMA6 Types

--- a/lib/type.js
+++ b/lib/type.js
@@ -26,8 +26,6 @@ var objectTypeRegexp = /^\[object (.*)\]$/;
 function getType(obj) {
   var type = Object.prototype.toString.call(obj).match(objectTypeRegexp)[1].toLowerCase();
   // Let "new String('')" return 'object'
-  if (type === 'string' && typeof obj === 'object') return 'object';
-  // Without support of @@toStringTag, Promise has type 'object'
   if (typeof Promise === 'function' && obj instanceof Promise) return 'promise';
   // PhantomJS has type "DOMWindow" for null
   if (obj === null) return 'null';

--- a/test/type.js
+++ b/test/type.js
@@ -30,10 +30,12 @@ describe('type(obj)', function () {
     assert('number' === type(-1.234));
     assert('number' === type(Infinity));
     assert('number' === type(NaN));
+    assert('number' === type(new Number(2)));
   });
 
   it('string', function () {
     assert('string' === type('hello world'));
+    assert('string' === type(new String('hello')));
   });
 
   it('null', function () {
@@ -52,7 +54,6 @@ describe('type(obj)', function () {
     assert('object' !== type(Noop));
     assert('object' === type(new Noop));
     assert('object' === type(new Object));
-    assert('object' === type(new String('hello')));
   });
 
   describe('New ECMA6 Types Stubbed', function () {


### PR DESCRIPTION
With all the dazzle about the promises, i totally forgot about the other Spec we were talking with `new String()` returning type `string` instead of `object`. I changed that now and also added a test to make sure `new Number()` actually returns type `number`.

Sorry for this :D