### PR TITLE
chore(build): add sauce_connect addon option to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 sudo: false
 language: node_js
+addons:
+  sauce_connect: true
 cache:
   directories:
     - node_modules


### PR DESCRIPTION
I forgot this option is needed for saucelabs to work in travis.