### PR TITLE
docs: Fixed gitter chat URL to point to chaijs-channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@
       src="https://img.shields.io/badge/slack-join%20chat-E2206F.svg?style=flat-square"
     />
   </a>
-  <a href="https://gitter.im/chaijs/type-detect">
+  <a href="https://gitter.im/chaijs/chai">
     <img
       alt="Join the Gitter chat"
       src="https://img.shields.io/badge/gitter-join%20chat-D0104D.svg?style=flat-square"


### PR DESCRIPTION
The gitter link pointed to a non existing channel *type-detect*. I pointed it to the chai-js channel.