### PR TITLE
test: Fix tests running in Node 6.0

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -217,7 +217,9 @@ describe('Generic', function () {
     var originalObjectToString = Object.prototype.toString;
     before(function () {
       global.Symbol = global.Symbol || {};
-      global.Symbol.toStringTag = global.Symbol.toStringTag || '__@@toStringTag__';
+      if (!global.Symbol.toStringTag) {
+        global.Symbol.toStringTag = '__@@toStringTag__';
+      }
       var test = {};
       test[Symbol.toStringTag] = function () {
         return 'foo';
@@ -238,12 +240,11 @@ describe('Generic', function () {
 
 
     it('plain object', function () {
-      var obj = {
-        '__@@toStringTag__': function () {
-          return 'Foo';
-        },
+      var obj = {};
+      obj[Symbol.toStringTag] = function () {
+        return 'Foo';
       };
-      assert(type(obj) === 'foo');
+      assert(type(obj) === 'foo', 'type(obj) === "foo"');
     });
 
   });


### PR DESCRIPTION
Symbol.toStringTag is an available read only property in Node 6. The tests overwrite the property
and as such were failing in Node 6.0. This fixes the tests so that they don't assign on Symbol
if the property already exists.

It also alters the tests to use Symbol.toStringTag proper, rather than the sham string - so that
when toStringTag actually exists, it is actually used rather than the sham; allowing tests to pass
in environments which support toStringTag for real.

@lucasfcosta @davelosert if you could please check this over and merge when happy 😄 