### PR TITLE
fix: check if Symbol.toStringTag exists before using

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,8 @@ var setExists = typeof Set !== 'undefined';
 var weakMapExists = typeof WeakMap !== 'undefined';
 var weakSetExists = typeof WeakSet !== 'undefined';
 var dataViewExists = typeof DataView !== 'undefined';
-var symbolIteratorExists = symbolExists && Symbol.iterator;
+var symbolIteratorExists = symbolExists && typeof Symbol.iterator !== 'undefined';
+var symbolToStringTagExists = symbolExists && typeof Symbol.toStringTag !== 'undefined';
 var setEntriesExists = setExists && typeof Set.prototype.entries === 'function';
 var mapEntriesExists = mapExists && typeof Map.prototype.entries === 'function';
 var setIteratorPrototype = getPrototypeOfExists && setEntriesExists && Object.getPrototypeOf(new Set().entries());
@@ -195,7 +196,7 @@ module.exports = function typeDetect(obj) {
     }
   }
 
-  if (getPrototypeOfExists && (symbolExists === false || typeof obj[Symbol.toStringTag] === 'undefined')) {
+  if (getPrototypeOfExists && (symbolToStringTagExists === false || typeof obj[Symbol.toStringTag] === 'undefined')) {
     var objPrototype = Object.getPrototypeOf(obj);
     /* ! Speed optimisation
     * Pre:

--- a/test/index.js
+++ b/test/index.js
@@ -60,6 +60,17 @@ describe('Generic', function () {
     assert(type(Object.create(Object.prototype)) === 'object');
   });
 
+  // See: https://github.com/chaijs/type-detect/pull/25
+  it('object with .undefined property getter', function () {
+    var foo = {};
+    Object.defineProperty(foo, 'undefined', {
+      get: function () {
+        throw Error('Should never happen');
+      },
+    });
+    assert(type(foo) === 'object');
+  });
+
   it('boolean', function () {
     assert(type(true) === 'boolean');
     assert(type(false) === 'boolean');


### PR DESCRIPTION
Some browser versions support `Symbol` but don't support `Symbol.toStringTag`, causing type-detect to always return `undefined`.

This PR fixes the bug and thus resolves the error identified by @davelosert in https://github.com/chaijs/chai/pull/640.