### PR TITLE
fix: fixed link for node formatting on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </h1>
 
 <p align=center>
-  Improved typeof detection for [node](http://nodejs.org) and the browser.
+  Improved typeof detection for <a href="http://nodejs.org">node</a> and the browser.
 </p>
 
 <p align=center>


### PR DESCRIPTION
As you can currently see on the README we've got a minor problem with the Node link.