### PR TITLE
Speed up tostringtag objects

### DIFF
--- a/bench/index.js
+++ b/bench/index.js
@@ -38,6 +38,19 @@ try {
 } catch (error) {
   console.error('cannot benchmark generator functions');
 }
+[
+  'Float64Array', 'Float32Array',
+  'Uint32Array', 'Uint16Array', 'Uint8Array',
+  'Int32Array', 'Int16Array', 'Int8Array',
+  'Uint8ClampedArray',
+].forEach(function (value) {
+  if (typeof global[value] === 'function') {
+    fixtures[value + new Array(19 - value.length).join(' ')] = new (global[value])(1);
+  }
+});
+if (typeof DataView === 'function') {
+  fixtures['DataView          '] = new DataView(new ArrayBuffer(1));
+}
 
 var filter = process.argv[2] || '';
 Object.keys(fixtures).filter(function (key) {

--- a/index.js
+++ b/index.js
@@ -196,7 +196,34 @@ module.exports = function typeDetect(obj) {
     }
   }
 
-  if (getPrototypeOfExists && (symbolToStringTagExists === false || typeof obj[Symbol.toStringTag] === 'undefined')) {
+  /* ! Speed optimisation
+  * Pre:
+  *   Float64Array       x 625,644 ops/sec ±1.58% (80 runs sampled)
+  *   Float32Array       x 1,279,852 ops/sec ±2.91% (77 runs sampled)
+  *   Uint32Array        x 1,178,185 ops/sec ±1.95% (83 runs sampled)
+  *   Uint16Array        x 1,008,380 ops/sec ±2.25% (80 runs sampled)
+  *   Uint8Array         x 1,128,040 ops/sec ±2.11% (81 runs sampled)
+  *   Int32Array         x 1,170,119 ops/sec ±2.88% (80 runs sampled)
+  *   Int16Array         x 1,176,348 ops/sec ±5.79% (86 runs sampled)
+  *   Int8Array          x 1,058,707 ops/sec ±4.94% (77 runs sampled)
+  *   Uint8ClampedArray  x 1,110,633 ops/sec ±4.20% (80 runs sampled)
+  * Post:
+  *   Float64Array       x 7,105,671 ops/sec ±13.47% (64 runs sampled)
+  *   Float32Array       x 5,887,912 ops/sec ±1.46% (82 runs sampled)
+  *   Uint32Array        x 6,491,661 ops/sec ±1.76% (79 runs sampled)
+  *   Uint16Array        x 6,559,795 ops/sec ±1.67% (82 runs sampled)
+  *   Uint8Array         x 6,463,966 ops/sec ±1.43% (85 runs sampled)
+  *   Int32Array         x 5,641,841 ops/sec ±3.49% (81 runs sampled)
+  *   Int16Array         x 6,583,511 ops/sec ±1.98% (80 runs sampled)
+  *   Int8Array          x 6,606,078 ops/sec ±1.74% (81 runs sampled)
+  *   Uint8ClampedArray  x 6,602,224 ops/sec ±1.77% (83 runs sampled)
+  */
+  var stringTag = (symbolToStringTagExists && obj[Symbol.toStringTag]);
+  if (typeof stringTag === 'string') {
+    return stringTag.toLowerCase();
+  }
+
+  if (getPrototypeOfExists) {
     var objPrototype = Object.getPrototypeOf(obj);
     /* ! Speed optimisation
     * Pre:


### PR DESCRIPTION
Im the midst of trying to speed up deep-eql I noticed that type detecting on typed arrays seemed to hit the slow path (`Object.prototype.toString.call`). That's when I noticed that we don't hit a path at all where if `toStringTag` is a string, we can just return early with it.

So this PR gives us a shortcut to getting to the final result, with what looks to be about a ~5-6x increase in ops/sec. 