### PR TITLE
perf: do not lowercase returned values

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,15 +104,15 @@ var type = require('type-detect');
 #### array
 
 ```js
-assert(type([]) === 'array');
-assert(type(new Array()) === 'array');
+assert(type([]) === 'Array');
+assert(type(new Array()) === 'Array');
 ```
 
 #### regexp
 
 ```js
-assert(type(/a-z/gi) === 'regexp');
-assert(type(new RegExp('a-z')) === 'regexp');
+assert(type(/a-z/gi) === 'RegExp');
+assert(type(new RegExp('a-z')) === 'RegExp');
 ```
 
 #### function
@@ -132,7 +132,7 @@ assert(type(function () {}) === 'function');
 #### date
 
 ```js
-assert(type(new Date) === 'date');
+assert(type(new Date) === 'Date');
 ```
 
 #### number
@@ -144,14 +144,14 @@ assert(type(-1) === 'number');
 assert(type(-1.234) === 'number');
 assert(type(Infinity) === 'number');
 assert(type(NaN) === 'number');
-assert(type(new Number(1)) === 'number');
+assert(type(new Number(1)) === 'Number'); // note - the object version has a capital N
 ```
 
 #### string
 
 ```js
 assert(type('hello world') === 'string');
-assert(type(new String('hello')) === 'string');
+assert(type(new String('hello')) === 'String'); // note - the object version has a capital S
 ```
 
 #### null
@@ -172,10 +172,10 @@ assert(type(null) !== 'undefined');
 
 ```js
 var Noop = function () {};
-assert(type({}) === 'object');
-assert(type(Noop) !== 'object');
-assert(type(new Noop) === 'object');
-assert(type(new Object) === 'object');
+assert(type({}) === 'Object');
+assert(type(Noop) !== 'Object');
+assert(type(new Noop) === 'Object');
+assert(type(new Object) === 'Object');
 ```
 
 #### ECMA6 Types
@@ -183,23 +183,23 @@ assert(type(new Object) === 'object');
 All new ECMAScript 2015 objects are also supported, such as Promises and Symbols:
 
 ```js
-assert(type(new Map() === 'map');
-assert(type(new WeakMap()) === 'weakmap');
-assert(type(new Set()) === 'set');
-assert(type(new WeakSet()) === 'weakset');
-assert(type(Symbol()) === 'symbol');
-assert(type(new Promise(callback) === 'promise');
-assert(type(new Int8Array()) === 'int8array');
-assert(type(new Uint8Array()) === 'uint8array');
-assert(type(new UInt8ClampedArray()) === 'uint8clampedarray');
-assert(type(new Int16Array()) === 'int16array');
-assert(type(new Uint16Array()) === 'uint16array');
-assert(type(new Int32Array()) === 'int32array');
-assert(type(new UInt32Array()) === 'uint32array');
-assert(type(new Float32Array()) === 'float32array');
-assert(type(new Float64Array()) === 'float64array');
-assert(type(new ArrayBuffer()) === 'arraybuffer');
-assert(type(new DataView(arrayBuffer)) === 'dataview');
+assert(type(new Map() === 'Map');
+assert(type(new WeakMap()) === 'WeakMap');
+assert(type(new Set()) === 'Set');
+assert(type(new WeakSet()) === 'WeakSet');
+assert(type(Symbol()) === 'Symbol');
+assert(type(new Promise(callback) === 'Promise');
+assert(type(new Int8Array()) === 'Int8Array');
+assert(type(new Uint8Array()) === 'Uint8Array');
+assert(type(new UInt8ClampedArray()) === 'Uint8ClampedArray');
+assert(type(new Int16Array()) === 'Int16Array');
+assert(type(new Uint16Array()) === 'Uint16Array');
+assert(type(new Int32Array()) === 'Int32Array');
+assert(type(new UInt32Array()) === 'Uint32Array');
+assert(type(new Float32Array()) === 'Float32Array');
+assert(type(new Float64Array()) === 'Float64Array');
+assert(type(new ArrayBuffer()) === 'ArrayBuffer');
+assert(type(new DataView(arrayBuffer)) === 'DataView');
 ```
 
 Also, if you use `Symbol.toStringTag` to change an Objects return value of the `toString()` Method, `type()` will return this value, e.g:

--- a/index.js
+++ b/index.js
@@ -95,7 +95,7 @@ module.exports = function typeDetect(obj) {
    *   array literal      x 22,479,650 ops/sec ±0.96% (81 runs sampled)
    */
   if (isArrayExists && Array.isArray(obj)) {
-    return 'array';
+    return 'Array';
   }
 
   if (isDom) {
@@ -107,7 +107,7 @@ module.exports = function typeDetect(obj) {
      *  - IE Edge <=13 === "[object Object]"
      */
     if (obj === globalObject.location) {
-      return 'location';
+      return 'Location';
     }
 
     /* ! Spec Conformance
@@ -130,7 +130,7 @@ module.exports = function typeDetect(obj) {
      *  - IE Edge <=13 === "[object HTMLDocument]"
      */
     if (obj === globalObject.document) {
-      return 'document';
+      return 'Document';
     }
 
     /* ! Spec Conformance
@@ -140,7 +140,7 @@ module.exports = function typeDetect(obj) {
      *  - IE <=10 === "[object MSMimeTypesCollection]"
      */
     if (obj === (globalObject.navigator || {}).mimeTypes) {
-      return 'mimetypearray';
+      return 'MimeTypeArray';
     }
 
     /* ! Spec Conformance
@@ -150,7 +150,7 @@ module.exports = function typeDetect(obj) {
      *  - IE <=10 === "[object MSPluginsCollection]"
      */
     if (obj === (globalObject.navigator || {}).plugins) {
-      return 'pluginarray';
+      return 'PluginArray';
     }
 
     /* ! Spec Conformance
@@ -160,7 +160,7 @@ module.exports = function typeDetect(obj) {
      *  - IE <=10 === "[object HTMLBlockElement]"
      */
     if (htmlElementExists && obj instanceof HTMLElement && obj.tagName === 'BLOCKQUOTE') {
-      return 'htmlquoteelement';
+      return 'HTMLQuoteElement';
     }
 
     /* ! Spec Conformance
@@ -176,7 +176,7 @@ module.exports = function typeDetect(obj) {
      *  - Safari === "[object HTMLTableCellElement]"
      */
     if (htmlElementExists && obj instanceof HTMLElement && obj.tagName === 'TD') {
-      return 'htmltabledatacellelement';
+      return 'HTMLTableDataCellElement';
     }
 
     /* ! Spec Conformance
@@ -192,7 +192,7 @@ module.exports = function typeDetect(obj) {
      *  - Safari === "[object HTMLTableCellElement]"
      */
     if (htmlElementExists && obj instanceof HTMLElement && obj.tagName === 'TH') {
-      return 'htmltableheadercellelement';
+      return 'HTMLTableHeaderCellElement';
     }
   }
 
@@ -220,7 +220,7 @@ module.exports = function typeDetect(obj) {
   */
   var stringTag = (symbolToStringTagExists && obj[Symbol.toStringTag]);
   if (typeof stringTag === 'string') {
-    return stringTag.toLowerCase();
+    return stringTag;
   }
 
   if (getPrototypeOfExists) {
@@ -234,7 +234,7 @@ module.exports = function typeDetect(obj) {
     *   regex constructor  x 3,931,108 ops/sec ±0.58% (84 runs sampled)
     */
     if (objPrototype === RegExp.prototype) {
-      return 'regexp';
+      return 'RegExp';
     }
 
     /* ! Speed optimisation
@@ -244,7 +244,7 @@ module.exports = function typeDetect(obj) {
     *   date               x 3,953,779 ops/sec ±1.35% (77 runs sampled)
     */
     if (objPrototype === Date.prototype) {
-      return 'date';
+      return 'Date';
     }
 
     /* ! Spec Conformance
@@ -257,7 +257,7 @@ module.exports = function typeDetect(obj) {
      *  - Safari 7.1-Latest === "[object Promise]"
      */
     if (promiseExists && objPrototype === Promise.prototype) {
-      return 'promise';
+      return 'Promise';
     }
 
     /* ! Speed optimisation
@@ -267,7 +267,7 @@ module.exports = function typeDetect(obj) {
     *   set                x 4,545,879 ops/sec ±1.13% (83 runs sampled)
     */
     if (setExists && objPrototype === Set.prototype) {
-      return 'set';
+      return 'Set';
     }
 
     /* ! Speed optimisation
@@ -277,7 +277,7 @@ module.exports = function typeDetect(obj) {
     *   map                x 4,183,945 ops/sec ±6.59% (82 runs sampled)
     */
     if (mapExists && objPrototype === Map.prototype) {
-      return 'map';
+      return 'Map';
     }
 
     /* ! Speed optimisation
@@ -287,7 +287,7 @@ module.exports = function typeDetect(obj) {
     *   weakset            x 4,237,510 ops/sec ±2.01% (77 runs sampled)
     */
     if (weakSetExists && objPrototype === WeakSet.prototype) {
-      return 'weakset';
+      return 'WeakSet';
     }
 
     /* ! Speed optimisation
@@ -297,7 +297,7 @@ module.exports = function typeDetect(obj) {
     *   weakmap            x 3,881,384 ops/sec ±1.45% (82 runs sampled)
     */
     if (weakMapExists && objPrototype === WeakMap.prototype) {
-      return 'weakmap';
+      return 'WeakMap';
     }
 
     /* ! Spec Conformance
@@ -307,7 +307,7 @@ module.exports = function typeDetect(obj) {
      *  - Edge <=13 === "[object Object]"
      */
     if (dataViewExists && objPrototype === DataView.prototype) {
-      return 'dataview';
+      return 'DataView';
     }
 
     /* ! Spec Conformance
@@ -317,7 +317,7 @@ module.exports = function typeDetect(obj) {
      *  - Edge <=13 === "[object Object]"
      */
     if (mapExists && objPrototype === mapIteratorPrototype) {
-      return 'map iterator';
+      return 'Map Iterator';
     }
 
     /* ! Spec Conformance
@@ -327,7 +327,7 @@ module.exports = function typeDetect(obj) {
      *  - Edge <=13 === "[object Object]"
      */
     if (setExists && objPrototype === setIteratorPrototype) {
-      return 'set iterator';
+      return 'Set Iterator';
     }
 
     /* ! Spec Conformance
@@ -337,7 +337,7 @@ module.exports = function typeDetect(obj) {
      *  - Edge <=13 === "[object Object]"
      */
     if (arrayIteratorExists && objPrototype === arrayIteratorPrototype) {
-      return 'array iterator';
+      return 'Array Iterator';
     }
 
     /* ! Spec Conformance
@@ -347,7 +347,7 @@ module.exports = function typeDetect(obj) {
      *  - Edge <=13 === "[object Object]"
      */
     if (stringIteratorExists && objPrototype === stringIteratorPrototype) {
-      return 'string iterator';
+      return 'String Iterator';
     }
 
     /* ! Speed optimisation
@@ -357,7 +357,7 @@ module.exports = function typeDetect(obj) {
     *   object from null   x 5,838,000 ops/sec ±0.99% (84 runs sampled)
     */
     if (objPrototype === null) {
-      return 'object';
+      return 'Object';
     }
   }
 
@@ -365,8 +365,7 @@ module.exports = function typeDetect(obj) {
     .prototype
     .toString
     .call(obj)
-    .slice(toStringLeftSliceLength, toStringRightSliceLength)
-    .toLowerCase();
+    .slice(toStringLeftSliceLength, toStringRightSliceLength);
 };
 
 module.exports.typeDetect = module.exports;

--- a/test/dom.js
+++ b/test/dom.js
@@ -14,35 +14,35 @@ describeIf(typeof window !== 'undefined' && typeof window.document !== 'undefine
   });
 
   it('document', function () {
-    assert(type(document) === 'document');
+    assert(type(document) === 'Document');
   });
 
   it('domparser', function () {
-    assert(type(new DOMParser()) === 'domparser');
+    assert(type(new DOMParser()) === 'DOMParser');
   });
 
   it('history', function () {
-    assert(type(window.history) === 'history');
+    assert(type(window.history) === 'History');
   });
 
   it('location', function () {
-    assert(type(window.location) === 'location');
+    assert(type(window.location) === 'Location');
   });
 
   it('attr', function () {
     var div = document.createElement('div');
     div.setAttribute('id', 'foo');
-    assert(type(div.getAttributeNode('id')) === 'attr');
+    assert(type(div.getAttributeNode('id')) === 'Attr');
   });
 
   describe('Events', function () {
 
     it('event', function () {
-      assert(type(document.createEvent('Event')) === 'event');
+      assert(type(document.createEvent('Event')) === 'Event');
     });
 
-    itIf(typeof HashChangeEvent !== 'undefined')('hashchangeevent', function () {
-      assert(type(new HashChangeEvent('')) === 'hashchangeevent');
+    itIf(typeof HashChangeEvent !== 'undefined')('HashChangeEvent', function () {
+      assert(type(new HashChangeEvent('')) === 'HashChangeEvent');
     });
 
   });
@@ -50,63 +50,63 @@ describeIf(typeof window !== 'undefined' && typeof window.document !== 'undefine
   describe('Navigator', function () {
 
     it('navigator', function () {
-      assert(type(window.navigator) === 'navigator');
+      assert(type(window.navigator) === 'Navigator');
     });
 
     itIf(typeof navigator !== 'undefined' && 'geolocation' in navigator)('geolocation', function () {
-      assert(type(navigator.geolocation) === 'geolocation');
+      assert(type(navigator.geolocation) === 'Geolocation');
     });
 
     itIf(typeof navigator !== 'undefined' && 'connection' in navigator)('networkinformation', function () {
-      assert(type(navigator.connection) === 'networkinformation');
+      assert(type(navigator.connection) === 'NetworkInformation');
     });
 
     itIf(typeof navigator !== 'undefined' && 'mediaDevices' in navigator)('mediadevices', function () {
-      assert(type(navigator.mediaDevices) === 'mediadevices');
+      assert(type(navigator.mediaDevices) === 'MediaDevices');
     });
 
     itIf(typeof navigator !== 'undefined' && 'mimeTypes' in navigator)('mimetypearray', function () {
-      assert(type(navigator.mimeTypes) === 'mimetypearray');
+      assert(type(navigator.mimeTypes) === 'MimeTypeArray');
     });
 
     itIf(typeof navigator !== 'undefined' && 'nfc' in navigator)('nfc', function () {
-      assert(type(navigator.nfc) === 'nfc');
+      assert(type(navigator.nfc) === 'NFC');
     });
 
     itIf(typeof navigator !== 'undefined' && 'permissions' in navigator)('permissions', function () {
-      assert(type(navigator.permissions) === 'permissions');
+      assert(type(navigator.permissions) === 'Permissions');
     });
 
     itIf(typeof navigator !== 'undefined' && 'plugins' in navigator)('pluginarray', function () {
-      assert(type(navigator.plugins) === 'pluginarray');
+      assert(type(navigator.plugins) === 'PluginArray');
     });
 
     itIf(typeof navigator !== 'undefined' && 'plugins' in navigator && navigator.plugins.length)('plugin', function () {
-      assert(type(navigator.plugins[0]) === 'plugin');
+      assert(type(navigator.plugins[0]) === 'Plugin');
     });
 
     itIf(typeof navigator !== 'undefined' && 'presentation' in navigator)('presentation', function () {
-      assert(type(navigator.presentation) === 'presentation');
+      assert(type(navigator.presentation) === 'Presentation');
     });
 
     itIf(typeof navigator !== 'undefined' && 'serviceworker' in navigator)('serviceworkercontainer', function () {
-      assert(type(navigator.serviceworker) === 'serviceworkercontainer');
+      assert(type(navigator.serviceworker) === 'ServiceWorkerContainer');
     });
 
     itIf(typeof navigator !== 'undefined' && 'services' in navigator)('serviceportcollection', function () {
-      assert(type(navigator.services) === 'serviceportcollection');
+      assert(type(navigator.services) === 'ServicePortCollection');
     });
 
     itIf(typeof navigator !== 'undefined' && 'storage' in navigator)('storagemanager', function () {
-      assert(type(navigator.storage) === 'storagemanager');
+      assert(type(navigator.storage) === 'StorageManager');
     });
 
     itIf(typeof navigator !== 'undefined' && 'storageQuota' in navigator)('storagequota', function () {
-      assert(type(navigator.storageQuota) === 'storagequota');
+      assert(type(navigator.storageQuota) === 'StorageQuota');
     });
 
     itIf(typeof navigator !== 'undefined' && 'usb' in navigator)('usb', function () {
-      assert(type(navigator.usb) === 'usb');
+      assert(type(navigator.usb) === 'USB');
     });
 
   });
@@ -114,217 +114,217 @@ describeIf(typeof window !== 'undefined' && typeof window.document !== 'undefine
   describe('(HTMLElements)', function () {
 
     it('HTMLAreaElement', function () {
-      assert(type(document.createElement('Area')) === 'htmlareaelement');
+      assert(type(document.createElement('Area')) === 'HTMLAreaElement');
     });
 
     it('HTMLBRElement', function () {
-      assert(type(document.createElement('BR')) === 'htmlbrelement');
+      assert(type(document.createElement('BR')) === 'HTMLBRElement');
     });
 
     it('HTMLBaseElement', function () {
-      assert(type(document.createElement('Base')) === 'htmlbaseelement');
+      assert(type(document.createElement('Base')) === 'HTMLBaseElement');
     });
 
     it('HTMLBodyElement', function () {
-      assert(type(document.createElement('Body')) === 'htmlbodyelement');
+      assert(type(document.createElement('Body')) === 'HTMLBodyElement');
     });
 
     it('HTMLButtonElement', function () {
-      assert(type(document.createElement('Button')) === 'htmlbuttonelement');
+      assert(type(document.createElement('Button')) === 'HTMLButtonElement');
     });
 
     it('HTMLCanvasElement', function () {
-      assert(type(document.createElement('Canvas')) === 'htmlcanvaselement');
+      assert(type(document.createElement('Canvas')) === 'HTMLCanvasElement');
     });
 
     it('HTMLDListElement', function () {
-      assert(type(document.createElement('DL')) === 'htmldlistelement');
+      assert(type(document.createElement('DL')) === 'HTMLDListElement');
     });
 
     // not yet supported in Safari
     itIf(typeof HTMLDataListElement === 'function')('HTMLDataListElement', function () {
-      assert(type(document.createElement('DataList')) === 'htmldatalistelement');
+      assert(type(document.createElement('DataList')) === 'HTMLDataListElement');
     });
 
     it('HTMLDivElement', function () {
-      assert(type(document.createElement('Div')) === 'htmldivelement');
+      assert(type(document.createElement('Div')) === 'HTMLDivElement');
     });
 
     it('HTMLFieldSetElement', function () {
-      assert(type(document.createElement('FieldSet')) === 'htmlfieldsetelement');
+      assert(type(document.createElement('FieldSet')) === 'HTMLFieldSetElement');
     });
 
     it('HTMLFormElement', function () {
-      assert(type(document.createElement('Form')) === 'htmlformelement');
+      assert(type(document.createElement('Form')) === 'HTMLFormElement');
     });
 
     it('HTMLFrameSetElement', function () {
-      assert(type(document.createElement('FrameSet')) === 'htmlframesetelement');
+      assert(type(document.createElement('FrameSet')) === 'HTMLFrameSetElement');
     });
 
     it('HTMLHRElement', function () {
-      assert(type(document.createElement('HR')) === 'htmlhrelement');
+      assert(type(document.createElement('HR')) === 'HTMLHRElement');
     });
 
     it('HTMLHeadElement', function () {
-      assert(type(document.createElement('Head')) === 'htmlheadelement');
+      assert(type(document.createElement('Head')) === 'HTMLHeadElement');
     });
 
     it('HTMLHeadingElement', function () {
-      assert(type(document.createElement('H1')) === 'htmlheadingelement');
-      assert(type(document.createElement('H2')) === 'htmlheadingelement');
-      assert(type(document.createElement('H3')) === 'htmlheadingelement');
-      assert(type(document.createElement('H4')) === 'htmlheadingelement');
-      assert(type(document.createElement('H5')) === 'htmlheadingelement');
-      assert(type(document.createElement('H6')) === 'htmlheadingelement');
+      assert(type(document.createElement('H1')) === 'HTMLHeadingElement');
+      assert(type(document.createElement('H2')) === 'HTMLHeadingElement');
+      assert(type(document.createElement('H3')) === 'HTMLHeadingElement');
+      assert(type(document.createElement('H4')) === 'HTMLHeadingElement');
+      assert(type(document.createElement('H5')) === 'HTMLHeadingElement');
+      assert(type(document.createElement('H6')) === 'HTMLHeadingElement');
     });
 
     it('HTMLHtmlElement', function () {
-      assert(type(document.createElement('Html')) === 'htmlhtmlelement');
+      assert(type(document.createElement('Html')) === 'HTMLHtmlElement');
     });
 
     it('HTMLIFrameElement', function () {
-      assert(type(document.createElement('IFrame')) === 'htmliframeelement');
+      assert(type(document.createElement('IFrame')) === 'HTMLIFrameElement');
     });
 
     it('HTMLImageElement', function () {
-      assert(type(document.createElement('Img')) === 'htmlimageelement');
+      assert(type(document.createElement('Img')) === 'HTMLImageElement');
     });
 
     it('HTMLInputElement', function () {
-      assert(type(document.createElement('Input')) === 'htmlinputelement');
+      assert(type(document.createElement('Input')) === 'HTMLInputElement');
     });
 
     it('HTMLLIElement', function () {
-      assert(type(document.createElement('LI')) === 'htmllielement');
+      assert(type(document.createElement('LI')) === 'HTMLLIElement');
     });
 
     it('HTMLLabelElement', function () {
-      assert(type(document.createElement('Label')) === 'htmllabelelement');
+      assert(type(document.createElement('Label')) === 'HTMLLabelElement');
     });
 
     it('HTMLLegendElement', function () {
-      assert(type(document.createElement('Legend')) === 'htmllegendelement');
+      assert(type(document.createElement('Legend')) === 'HTMLLegendElement');
     });
 
     it('HTMLLinkElement', function () {
-      assert(type(document.createElement('Link')) === 'htmllinkelement');
+      assert(type(document.createElement('Link')) === 'HTMLLinkElement');
     });
 
     it('HTMLMapElement', function () {
-      assert(type(document.createElement('Map')) === 'htmlmapelement');
+      assert(type(document.createElement('Map')) === 'HTMLMapElement');
     });
 
     it('HTMLMetaElement', function () {
-      assert(type(document.createElement('Meta')) === 'htmlmetaelement');
+      assert(type(document.createElement('Meta')) === 'HTMLMetaElement');
     });
 
     itIf(typeof HTMLMeterElement !== 'undefined')('HTMLMeterElement', function () {
-      assert(type(document.createElement('Meter')) === 'htmlmeterelement');
+      assert(type(document.createElement('Meter')) === 'HTMLMeterElement');
     });
 
     it('HTMLModElement', function () {
-      assert(type(document.createElement('Del')) === 'htmlmodelement');
+      assert(type(document.createElement('Del')) === 'HTMLModElement');
     });
 
     it('HTMLOListElement', function () {
-      assert(type(document.createElement('OL')) === 'htmlolistelement');
+      assert(type(document.createElement('OL')) === 'HTMLOListElement');
     });
 
     it('HTMLOptGroupElement', function () {
-      assert(type(document.createElement('OptGroup')) === 'htmloptgroupelement');
+      assert(type(document.createElement('OptGroup')) === 'HTMLOptGroupElement');
     });
 
     it('HTMLOptionElement', function () {
-      assert(type(document.createElement('Option')) === 'htmloptionelement');
+      assert(type(document.createElement('Option')) === 'HTMLOptionElement');
     });
 
     itIf(typeof HTMLOutputElement !== 'undefined')('HTMLOutputElement', function () {
-      assert(type(document.createElement('Output')) === 'htmloutputelement');
+      assert(type(document.createElement('Output')) === 'HTMLOutputElement');
     });
 
     it('HTMLParagraphElement', function () {
-      assert(type(document.createElement('P')) === 'htmlparagraphelement');
+      assert(type(document.createElement('P')) === 'HTMLParagraphElement');
     });
 
     it('HTMLParamElement', function () {
-      assert(type(document.createElement('Param')) === 'htmlparamelement');
+      assert(type(document.createElement('Param')) === 'HTMLParamElement');
     });
 
     it('HTMLPreElement', function () {
-      assert(type(document.createElement('Pre')) === 'htmlpreelement');
+      assert(type(document.createElement('Pre')) === 'HTMLPreElement');
     });
 
     itIf(typeof HTMLProgressElement !== 'undefined')('HTMLProgressElement', function () {
-      assert(type(document.createElement('Progress')) === 'htmlprogresselement');
+      assert(type(document.createElement('Progress')) === 'HTMLProgressElement');
     });
 
     it('HTMLQuoteElement', function () {
-      assert(type(document.createElement('BlockQuote')) === 'htmlquoteelement');
-      assert(type(document.createElement('Q')) === 'htmlquoteelement');
+      assert(type(document.createElement('BlockQuote')) === 'HTMLQuoteElement');
+      assert(type(document.createElement('Q')) === 'HTMLQuoteElement');
     });
 
     it('HTMLScriptElement', function () {
-      assert(type(document.createElement('Script')) === 'htmlscriptelement');
+      assert(type(document.createElement('Script')) === 'HTMLScriptElement');
     });
 
     it('HTMLSelectElement', function () {
-      assert(type(document.createElement('Select')) === 'htmlselectelement');
+      assert(type(document.createElement('Select')) === 'HTMLSelectElement');
     });
 
     it('HTMLSpanElement', function () {
-      assert(type(document.createElement('Span')) === 'htmlspanelement');
+      assert(type(document.createElement('Span')) === 'HTMLSpanElement');
     });
 
     it('HTMLStyleElement', function () {
-      assert(type(document.createElement('Style')) === 'htmlstyleelement');
+      assert(type(document.createElement('Style')) === 'HTMLStyleElement');
     });
 
     it('HTMLTableCaptionElement', function () {
-      assert(type(document.createElement('Caption')) === 'htmltablecaptionelement');
+      assert(type(document.createElement('Caption')) === 'HTMLTableCaptionElement');
     });
 
     it('HTMLTableDataCellElement', function () {
-      assert(type(document.createElement('TD')) === 'htmltabledatacellelement');
+      assert(type(document.createElement('TD')) === 'HTMLTableDataCellElement');
     });
 
     it('HTMLTableHeaderCellElement', function () {
-      assert(type(document.createElement('TH')) === 'htmltableheadercellelement');
+      assert(type(document.createElement('TH')) === 'HTMLTableHeaderCellElement');
     });
 
     it('HTMLTableColElement', function () {
-      assert(type(document.createElement('Col')) === 'htmltablecolelement');
-      assert(type(document.createElement('ColGroup')) === 'htmltablecolelement');
+      assert(type(document.createElement('Col')) === 'HTMLTableColElement');
+      assert(type(document.createElement('ColGroup')) === 'HTMLTableColElement');
     });
 
     it('HTMLTableElement', function () {
-      assert(type(document.createElement('Table')) === 'htmltableelement');
+      assert(type(document.createElement('Table')) === 'HTMLTableElement');
     });
 
     it('HTMLTableRowElement', function () {
-      assert(type(document.createElement('TR')) === 'htmltablerowelement');
+      assert(type(document.createElement('TR')) === 'HTMLTableRowElement');
     });
 
     it('HTMLTableSectionElement', function () {
-      assert(type(document.createElement('THead')) === 'htmltablesectionelement');
-      assert(type(document.createElement('TBody')) === 'htmltablesectionelement');
-      assert(type(document.createElement('TFoot')) === 'htmltablesectionelement');
+      assert(type(document.createElement('THead')) === 'HTMLTableSectionElement');
+      assert(type(document.createElement('TBody')) === 'HTMLTableSectionElement');
+      assert(type(document.createElement('TFoot')) === 'HTMLTableSectionElement');
     });
 
     it('HTMLTextAreaElement', function () {
-      assert(type(document.createElement('TextArea')) === 'htmltextareaelement');
+      assert(type(document.createElement('TextArea')) === 'HTMLTextAreaElement');
     });
 
     it('HTMLTitleElement', function () {
-      assert(type(document.createElement('Title')) === 'htmltitleelement');
+      assert(type(document.createElement('Title')) === 'HTMLTitleElement');
     });
 
     it('HTMLUListElement', function () {
-      assert(type(document.createElement('UL')) === 'htmlulistelement');
+      assert(type(document.createElement('UL')) === 'HTMLUListElement');
     });
 
     it('HTMLUnknownElement', function () {
-      assert(type(document.createElement('foobarbaz')) === 'htmlunknownelement');
+      assert(type(document.createElement('foobarbaz')) === 'HTMLUnknownElement');
     });
 
   });

--- a/test/index.js
+++ b/test/index.js
@@ -4,13 +4,13 @@ var type = require('..');
 describe('Generic', function () {
 
   it('array', function () {
-    assert(type([]) === 'array');
-    assert(type(new Array()) === 'array');
+    assert(type([]) === 'Array');
+    assert(type(new Array()) === 'Array');
   });
 
   it('regexp', function () {
-    assert(type(/a-z/gi) === 'regexp');
-    assert(type(new RegExp('a-z')) === 'regexp');
+    assert(type(/a-z/gi) === 'RegExp');
+    assert(type(new RegExp('a-z')) === 'RegExp');
   });
 
   it('function', function () {
@@ -18,11 +18,11 @@ describe('Generic', function () {
   });
 
   it('arguments', function () {
-    assert(type(arguments) === 'arguments');
+    assert(type(arguments) === 'Arguments');
   });
 
   it('date', function () {
-    assert(type(new Date()) === 'date');
+    assert(type(new Date()) === 'Date');
   });
 
   it('number', function () {
@@ -32,12 +32,18 @@ describe('Generic', function () {
     assert(type(-1.234) === 'number');
     assert(type(Infinity) === 'number');
     assert(type(NaN) === 'number');
-    assert(type(new Number(2)) === 'number');
+  });
+
+  it('number objects', function () {
+    assert(type(new Number(2)) === 'Number');
   });
 
   it('string', function () {
     assert(type('hello world') === 'string');
-    assert(type(new String('hello')) === 'string');
+  });
+
+  it('string objects', function () {
+    assert(type(new String('hello')) === 'String');
   });
 
   it('null', function () {
@@ -52,12 +58,12 @@ describe('Generic', function () {
 
   it('object', function () {
     function Noop() {}
-    assert(type({}) === 'object');
-    assert(type(Noop) !== 'object');
-    assert(type(new Noop()) === 'object');
-    assert(type(new Object()) === 'object');
-    assert(type(Object.create(null)) === 'object');
-    assert(type(Object.create(Object.prototype)) === 'object');
+    assert(type({}) === 'Object');
+    assert(type(Noop) !== 'Object');
+    assert(type(new Noop()) === 'Object');
+    assert(type(new Object()) === 'Object');
+    assert(type(Object.create(null)) === 'Object');
+    assert(type(Object.create(Object.prototype)) === 'Object');
   });
 
   // See: https://github.com/chaijs/type-detect/pull/25
@@ -68,33 +74,36 @@ describe('Generic', function () {
         throw Error('Should never happen');
       },
     });
-    assert(type(foo) === 'object');
+    assert(type(foo) === 'Object');
   });
 
   it('boolean', function () {
     assert(type(true) === 'boolean');
     assert(type(false) === 'boolean');
-    assert(type(new Boolean()) === 'boolean');
     assert(type(!0) === 'boolean');
   });
 
+  it('boolean object', function () {
+    assert(type(new Boolean()) === 'Boolean');
+  });
+
   it('error', function () {
-    assert(type(new Error()) === 'error');
-    assert(type(new TypeError()) === 'error');
-    assert(type(new EvalError()) === 'error');
-    assert(type(new RangeError()) === 'error');
-    assert(type(new ReferenceError()) === 'error');
-    assert(type(new SyntaxError()) === 'error');
-    assert(type(new TypeError()) === 'error');
-    assert(type(new URIError()) === 'error');
+    assert(type(new Error()) === 'Error');
+    assert(type(new TypeError()) === 'Error');
+    assert(type(new EvalError()) === 'Error');
+    assert(type(new RangeError()) === 'Error');
+    assert(type(new ReferenceError()) === 'Error');
+    assert(type(new SyntaxError()) === 'Error');
+    assert(type(new TypeError()) === 'Error');
+    assert(type(new URIError()) === 'Error');
   });
 
   it('Math', function () {
-    assert(type(Math) === 'math');
+    assert(type(Math) === 'Math');
   });
 
   it('JSON', function () {
-    assert(type(JSON) === 'json');
+    assert(type(JSON) === 'JSON');
   });
 
   describe('Stubbed ES2015 Types', function () {
@@ -109,117 +118,117 @@ describe('Generic', function () {
 
     it('map', function () {
       stubObjectToStringOnce('[object Map]');
-      assert(type(new Thing()) === 'map');
+      assert(type(new Thing()) === 'Map');
     });
 
     it('weakmap', function () {
       stubObjectToStringOnce('[object WeakMap]');
-      assert(type(new Thing()) === 'weakmap');
+      assert(type(new Thing()) === 'WeakMap');
     });
 
     it('set', function () {
       stubObjectToStringOnce('[object Set]');
-      assert(type(new Thing()) === 'set');
+      assert(type(new Thing()) === 'Set');
     });
 
     it('weakset', function () {
       stubObjectToStringOnce('[object WeakSet]');
-      assert(type(new Thing()) === 'weakset');
+      assert(type(new Thing()) === 'WeakSet');
     });
 
     it('symbol', function () {
       stubObjectToStringOnce('[object Symbol]');
-      assert(type(new Thing()) === 'symbol');
+      assert(type(new Thing()) === 'Symbol');
     });
 
     it('promise', function () {
       stubObjectToStringOnce('[object Promise]');
-      assert(type(new Thing()) === 'promise');
+      assert(type(new Thing()) === 'Promise');
     });
 
     it('int8array', function () {
       stubObjectToStringOnce('[object Int8Array]');
-      assert(type(new Thing()) === 'int8array');
+      assert(type(new Thing()) === 'Int8Array');
     });
 
     it('uint8array', function () {
       stubObjectToStringOnce('[object Uint8Array]');
-      assert(type(new Thing()) === 'uint8array');
+      assert(type(new Thing()) === 'Uint8Array');
     });
 
     it('uint8clampedarray', function () {
       stubObjectToStringOnce('[object Uint8ClampedArray]');
-      assert(type(new Thing()) === 'uint8clampedarray');
+      assert(type(new Thing()) === 'Uint8ClampedArray');
     });
 
     it('int16array', function () {
       stubObjectToStringOnce('[object Int16Array]');
-      assert(type(new Thing()) === 'int16array');
+      assert(type(new Thing()) === 'Int16Array');
     });
 
     it('uint16array', function () {
       stubObjectToStringOnce('[object Uint16Array]');
-      assert(type(new Thing()) === 'uint16array');
+      assert(type(new Thing()) === 'Uint16Array');
     });
 
     it('int32array', function () {
       stubObjectToStringOnce('[object Int32Array]');
-      assert(type(new Thing()) === 'int32array');
+      assert(type(new Thing()) === 'Int32Array');
     });
 
     it('uint32array', function () {
       stubObjectToStringOnce('[object Uint32Array]');
-      assert(type(new Thing()) === 'uint32array');
+      assert(type(new Thing()) === 'Uint32Array');
     });
 
     it('float32array', function () {
       stubObjectToStringOnce('[object Float32Array]');
-      assert(type(new Thing()) === 'float32array');
+      assert(type(new Thing()) === 'Float32Array');
     });
 
     it('float64array', function () {
       stubObjectToStringOnce('[object Float64Array]');
-      assert(type(new Thing()) === 'float64array');
+      assert(type(new Thing()) === 'Float64Array');
     });
 
     it('dataview', function () {
       stubObjectToStringOnce('[object DataView]');
-      assert(type(new Thing()) === 'dataview');
+      assert(type(new Thing()) === 'DataView');
     });
 
     it('arraybuffer', function () {
       stubObjectToStringOnce('[object ArrayBuffer]');
-      assert(type(new Thing()) === 'arraybuffer');
+      assert(type(new Thing()) === 'ArrayBuffer');
     });
 
     it('generatorfunction', function () {
       stubObjectToStringOnce('[object GeneratorFunction]');
-      assert(type(new Thing()) === 'generatorfunction');
+      assert(type(new Thing()) === 'GeneratorFunction');
     });
 
     it('generator', function () {
       stubObjectToStringOnce('[object Generator]');
-      assert(type(new Thing()) === 'generator');
+      assert(type(new Thing()) === 'Generator');
     });
 
     it('string iterator', function () {
       stubObjectToStringOnce('[object String Iterator]');
-      assert(type(new Thing()) === 'string iterator');
+      assert(type(new Thing()) === 'String Iterator');
     });
 
     it('array iterator', function () {
       stubObjectToStringOnce('[object Array Iterator]');
-      assert(type(new Thing()) === 'array iterator');
+      assert(type(new Thing()) === 'Array Iterator');
     });
 
     it('map iterator', function () {
       stubObjectToStringOnce('[object Map Iterator]');
-      assert(type(new Thing()) === 'map iterator');
+      assert(type(new Thing()) === 'Map Iterator');
     });
 
     it('set iterator', function () {
       stubObjectToStringOnce('[object Set Iterator]');
-      assert(type(new Thing()) === 'set iterator');
+      assert(type(new Thing()) === 'Set Iterator');
     });
 
   });
@@ -255,7 +264,7 @@ describe('Generic', function () {
       obj[Symbol.toStringTag] = function () {
         return 'Foo';
       };
-      assert(type(obj) === 'foo', 'type(obj) === "foo"');
+      assert(type(obj) === 'Foo', 'type(obj) === "Foo"');
     });
 
   });

--- a/test/new-ecmascript-types.js
+++ b/test/new-ecmascript-types.js
@@ -24,47 +24,47 @@ function itIf(condition) {
 
 describe('ES2015 Specific', function () {
   itIf(symbolExists && typeof String.prototype[Symbol.iterator] === 'function')('string iterator', function () {
-    assert(type(''[Symbol.iterator]()) === 'string iterator');
+    assert(type(''[Symbol.iterator]()) === 'String Iterator');
   });
 
   itIf(symbolExists && typeof Array.prototype[Symbol.iterator] === 'function')('array iterator', function () {
-    assert(type([][Symbol.iterator]()) === 'array iterator');
+    assert(type([][Symbol.iterator]()) === 'Array Iterator');
   });
 
   itIf(typeof Array.prototype.entries === 'function')('array iterator (entries)', function () {
-    assert(type([].entries()) === 'array iterator');
+    assert(type([].entries()) === 'Array Iterator');
   });
 
   itIf(mapExists)('map', function () {
-    assert(type(new Map()) === 'map');
+    assert(type(new Map()) === 'Map');
   });
 
   itIf(symbolExists && mapExists && typeof Map.prototype[Symbol.iterator] === 'function')('map iterator', function () {
-    assert(type(new Map()[Symbol.iterator]()) === 'map iterator');
+    assert(type(new Map()[Symbol.iterator]()) === 'Map Iterator');
   });
 
   itIf(mapExists && typeof Map.prototype.entries === 'function')('map iterator (entries)', function () {
-    assert(type(new Map().entries()) === 'map iterator');
+    assert(type(new Map().entries()) === 'Map Iterator');
   });
 
   itIf(typeof WeakMap === 'function')('weakmap', function () {
-    assert(type(new WeakMap()) === 'weakmap');
+    assert(type(new WeakMap()) === 'WeakMap');
   });
 
   itIf(setExists)('set', function () {
-    assert(type(new Set()) === 'set');
+    assert(type(new Set()) === 'Set');
   });
 
   itIf(symbolExists && setExists && typeof Set.prototype[Symbol.iterator] === 'function')('set iterator', function () {
-    assert(type(new Set()[Symbol.iterator]()) === 'set iterator');
+    assert(type(new Set()[Symbol.iterator]()) === 'Set Iterator');
   });
 
   itIf(setExists && typeof Set.prototype.entries === 'function')('set iterator', function () {
-    assert(type(new Set().entries()) === 'set iterator');
+    assert(type(new Set().entries()) === 'Set Iterator');
   });
 
   itIf(typeof WeakSet === 'function')('weakset', function () {
-    assert(type(new WeakSet()) === 'weakset');
+    assert(type(new WeakSet()) === 'WeakSet');
   });
 
   itIf(typeof Symbol === 'function')('symbol', function () {
@@ -73,52 +73,52 @@ describe('ES2015 Specific', function () {
 
   itIf(typeof Promise === 'function')('promise', function () {
     function noop() {}
-    assert(type(new Promise(noop)) === 'promise');
+    assert(type(new Promise(noop)) === 'Promise');
   });
 
   itIf(typeof Int8Array === 'function')('int8array', function () {
-    assert(type(new Int8Array()) === 'int8array');
+    assert(type(new Int8Array()) === 'Int8Array');
   });
 
   itIf(typeof Uint8Array === 'function')('uint8array', function () {
-    assert(type(new Uint8Array()) === 'uint8array');
+    assert(type(new Uint8Array()) === 'Uint8Array');
   });
 
   itIf(typeof Uint8ClampedArray === 'function')('uint8clampedarray', function () {
-    assert(type(new Uint8ClampedArray()) === 'uint8clampedarray');
+    assert(type(new Uint8ClampedArray()) === 'Uint8ClampedArray');
   });
 
   itIf(typeof Int16Array === 'function')('int16array', function () {
-    assert(type(new Int16Array()) === 'int16array');
+    assert(type(new Int16Array()) === 'Int16Array');
   });
 
   itIf(typeof Uint16Array === 'function')('uint16array', function () {
-    assert(type(new Uint16Array()) === 'uint16array');
+    assert(type(new Uint16Array()) === 'Uint16Array');
   });
 
   itIf(typeof Int32Array === 'function')('int32array', function () {
-    assert(type(new Int32Array()) === 'int32array');
+    assert(type(new Int32Array()) === 'Int32Array');
   });
 
   itIf(typeof Uint32Array === 'function')('uint32array', function () {
-    assert(type(new Uint32Array()) === 'uint32array');
+    assert(type(new Uint32Array()) === 'Uint32Array');
   });
 
   itIf(typeof Float32Array === 'function')('float32array', function () {
-    assert(type(new Float32Array()) === 'float32array');
+    assert(type(new Float32Array()) === 'Float32Array');
   });
 
   itIf(typeof Float64Array === 'function')('float64array', function () {
-    assert(type(new Float64Array()) === 'float64array');
+    assert(type(new Float64Array()) === 'Float64Array');
   });
 
   itIf(typeof DataView === 'function')('dataview', function () {
     var arrayBuffer = new ArrayBuffer(1);
-    assert(type(new DataView(arrayBuffer)) === 'dataview');
+    assert(type(new DataView(arrayBuffer)) === 'DataView');
   });
 
   itIf(typeof ArrayBuffer === 'function')('arraybuffer', function () {
-    assert(type(new ArrayBuffer(1)) === 'arraybuffer');
+    assert(type(new ArrayBuffer(1)) === 'ArrayBuffer');
   });
 
   itIf(supportArrows)('arrow function', function () {
@@ -130,7 +130,7 @@ describe('ES2015 Specific', function () {
   });
 
   itIf(supportGenerators)('generator', function () {
-    assert(type(eval('(function * foo () {}())')) === 'generator'); // eslint-disable-line no-eval
+    assert(type(eval('(function * foo () {}())')) === 'Generator'); // eslint-disable-line no-eval
   });
 
 });


### PR DESCRIPTION
We're sacrificing a lot of performance just to lowercase the string values, which is not ideal as it's not always necessary. Here are some numbers demonstrating the difference in performance:

With `.toLowerCase()`:
```
string literal     x 31,742,089 ops/sec ±6.85% (70 runs sampled)
array literal      x 12,508,545 ops/sec ±3.86% (67 runs sampled)
boolean literal    x 33,502,011 ops/sec ±3.58% (66 runs sampled)
object literal     x 1,178,855 ops/sec ±2.06% (79 runs sampled)
object from null   x 3,356,249 ops/sec ±2.03% (81 runs sampled)
regex literal      x 2,738,477 ops/sec ±1.95% (80 runs sampled)
number literal     x 30,119,855 ops/sec ±2.04% (78 runs sampled)
promise            x 7,260,140 ops/sec ±1.79% (81 runs sampled)
null               x 34,793,675 ops/sec ±1.58% (84 runs sampled)
undefined          x 31,537,228 ops/sec ±1.77% (81 runs sampled)
function           x 35,571,426 ops/sec ±1.69% (82 runs sampled)
buffer             x 5,468,033 ops/sec ±2.19% (83 runs sampled)
date               x 4,402,505 ops/sec ±1.47% (83 runs sampled)
error              x 932,833 ops/sec ±2.16% (80 runs sampled)
map                x 7,298,659 ops/sec ±1.64% (81 runs sampled)
regex constructor  x 3,042,918 ops/sec ±2.28% (80 runs sampled)
set                x 6,075,985 ops/sec ±1.91% (82 runs sampled)
string constructor x 1,077,682 ops/sec ±2.32% (82 runs sampled)
weakmap            x 5,949,120 ops/sec ±1.99% (83 runs sampled)
weakset            x 5,574,794 ops/sec ±1.89% (78 runs sampled)
arguments          x 1,065,249 ops/sec ±1.37% (83 runs sampled)
arrow function     x 28,776,605 ops/sec ±1.61% (81 runs sampled)
generator function x 34,581,601 ops/sec ±2.11% (79 runs sampled)
Float64Array       x 5,306,129 ops/sec ±1.64% (83 runs sampled)
Float32Array       x 5,635,134 ops/sec ±1.37% (84 runs sampled)
Uint32Array        x 5,584,889 ops/sec ±1.72% (83 runs sampled)
Uint16Array        x 5,024,561 ops/sec ±1.40% (85 runs sampled)
Uint8Array         x 5,032,024 ops/sec ±1.93% (81 runs sampled)
Int32Array         x 6,261,825 ops/sec ±2.21% (78 runs sampled)
Int16Array         x 6,380,182 ops/sec ±1.68% (81 runs sampled)
Int8Array          x 6,156,981 ops/sec ±2.27% (78 runs sampled)
Uint8ClampedArray  x 5,911,482 ops/sec ±1.85% (80 runs sampled)
DataView           x 7,308,534 ops/sec ±1.83% (78 runs sampled)
```

Without `.toLowerCase()`:
```
string literal     x 47,522,814 ops/sec ±1.93% (80 runs sampled)
array literal      x 18,729,054 ops/sec ±1.88% (81 runs sampled)
boolean literal    x 33,037,749 ops/sec ±2.17% (83 runs sampled)
object literal     x 1,536,749 ops/sec ±2.99% (80 runs sampled)
object from null   x 3,148,007 ops/sec ±2.39% (83 runs sampled)
regex literal      x 3,373,384 ops/sec ±1.82% (82 runs sampled)
number literal     x 33,096,650 ops/sec ±1.43% (85 runs sampled)
promise            x 13,416,347 ops/sec ±1.62% (80 runs sampled)
null               x 32,376,000 ops/sec ±1.70% (82 runs sampled)
undefined          x 30,734,992 ops/sec ±1.60% (82 runs sampled)
function           x 35,044,726 ops/sec ±1.87% (81 runs sampled)
buffer             x 10,831,858 ops/sec ±1.93% (82 runs sampled)
date               x 4,511,245 ops/sec ±1.99% (81 runs sampled)
error              x 836,481 ops/sec ±2.31% (79 runs sampled)
map                x 14,289,403 ops/sec ±1.72% (83 runs sampled)
regex constructor  x 3,764,635 ops/sec ±2.69% (78 runs sampled)
set                x 12,494,254 ops/sec ±1.95% (82 runs sampled)
string constructor x 1,282,794 ops/sec ±1.92% (80 runs sampled)
weakmap            x 15,418,935 ops/sec ±1.84% (79 runs sampled)
weakset            x 14,768,545 ops/sec ±1.60% (82 runs sampled)
arguments          x 993,064 ops/sec ±1.88% (81 runs sampled)
arrow function     x 30,511,620 ops/sec ±2.07% (79 runs sampled)
generator function x 35,487,241 ops/sec ±1.53% (81 runs sampled)
Float64Array       x 9,666,668 ops/sec ±1.75% (79 runs sampled)
Float32Array       x 9,286,265 ops/sec ±1.66% (81 runs sampled)
Uint32Array        x 9,352,490 ops/sec ±1.37% (82 runs sampled)
Uint16Array        x 8,404,961 ops/sec ±2.03% (80 runs sampled)
Uint8Array         x 8,635,152 ops/sec ±1.81% (80 runs sampled)
Int32Array         x 10,569,543 ops/sec ±1.67% (82 runs sampled)
Int16Array         x 9,444,358 ops/sec ±1.53% (80 runs sampled)
Int8Array          x 7,235,174 ops/sec ±2.43% (76 runs sampled)
Uint8ClampedArray  x 8,055,645 ops/sec ±1.67% (82 runs sampled)
DataView           x 15,014,475 ops/sec ±2.08% (79 runs sampled)
```

BREAKING CHANGE:

All strings will no longer be lowercase. If you want them in lowercase,
simply add `.toLowerCase()` to the return value.

@meeber @lucasfcosta this should be released as `v3.0.0` due to `BREAKING CHANGE:` in the commit.