### PR TITLE
Don't assume HTMLElement is in the global scope

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,20 +8,16 @@
 var promiseExists = typeof Promise === 'function';
 
 /* eslint-disable no-undef */
-var isDom = false;
 var globalObject = typeof self === 'object' ? self : global; // eslint-disable-line id-blacklist
 
 /*
  * All of these attributes must be available on the global object for the current environment
  * to be considered a DOM environment (browser)
  */
-if (typeof window === 'object' &&
+var isDom = typeof window === 'object' &&
   'document' in window &&
   'navigator' in window &&
-  'HTMLElement' in window
-) {
-  isDom = true;
-}
+  'HTMLElement' in window;
 
 var symbolExists = typeof Symbol !== 'undefined';
 var mapExists = typeof Map !== 'undefined';

--- a/index.js
+++ b/index.js
@@ -7,15 +7,13 @@
  */
 var promiseExists = typeof Promise === 'function';
 
-/* eslint-disable */
 // See http://stackoverflow.com/a/6930376
-var globalObject;
+var globalObject = null;
 try {
-  globalObject = Function('return this')() || (42, eval)('this');
-} catch (e) {
-  globalObject = window;
+  globalObject = Function('return this')() || (0, eval)('this'); // eslint-disable-line no-new-func, no-eval
+} catch (ignoredError) {
+  globalObject = window; // eslint-disable-line no-undef
 }
-/* eslint-enable */
 
 /*
  * All of these attributes must be available on the global object for the current environment

--- a/index.js
+++ b/index.js
@@ -21,7 +21,6 @@ if (typeof window === 'object' &&
   'HTMLElement' in window
 ) {
   isDom = true;
-  globalObject = window; // eslint-disable-line no-undef
 }
 
 var symbolExists = typeof Symbol !== 'undefined';

--- a/index.js
+++ b/index.js
@@ -5,8 +5,29 @@
  * MIT Licensed
  */
 var promiseExists = typeof Promise === 'function';
-var globalObject = typeof window !== 'undefined' ? window : typeof global !== 'undefined' ? global : self; // eslint-disable-line
-var isDom = 'location' in globalObject && 'document' in globalObject;
+
+// See http://stackoverflow.com/a/6930376
+var globalObject;
+try {
+  globalObject = Function('return this')() || (42, eval)('this');
+} catch (e) {
+  globalObject = window;
+}
+
+/*
+ * All of these attributes must be available on the global object for the current environment
+ * to be considered a DOM environment (browser)
+ */
+var domIndicatorAttributes = [
+  'location',
+  'document',
+  'navigator',
+  'HTMLElement'
+];
+var isDom = domIndicatorAttributes.every(function(attr) {
+  return attr in globalObject;
+});
+
 var symbolExists = typeof Symbol !== 'undefined';
 var mapExists = typeof Map !== 'undefined';
 var setExists = typeof Set !== 'undefined';
@@ -156,7 +177,7 @@ module.exports = function typeDetect(obj) {
      * Test: `Object.prototype.toString.call(document.createElement('blockquote'))``
      *  - IE <=10 === "[object HTMLBlockElement]"
      */
-    if (obj instanceof globalObject.HTMLElement && obj.tagName === 'BLOCKQUOTE') {
+    if (obj instanceof HTMLElement && obj.tagName === 'BLOCKQUOTE') {
       return 'HTMLQuoteElement';
     }
 
@@ -172,7 +193,7 @@ module.exports = function typeDetect(obj) {
      *  - Firefox === "[object HTMLTableCellElement]"
      *  - Safari === "[object HTMLTableCellElement]"
      */
-    if (obj instanceof globalObject.HTMLElement && obj.tagName === 'TD') {
+    if (obj instanceof HTMLElement && obj.tagName === 'TD') {
       return 'HTMLTableDataCellElement';
     }
 
@@ -188,7 +209,7 @@ module.exports = function typeDetect(obj) {
      *  - Firefox === "[object HTMLTableCellElement]"
      *  - Safari === "[object HTMLTableCellElement]"
      */
-    if (obj instanceof globalObject.HTMLElement && obj.tagName === 'TH') {
+    if (obj instanceof HTMLElement && obj.tagName === 'TH') {
       return 'HTMLTableHeaderCellElement';
     }
   }

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 'use strict';
+
 /* !
  * type-detect
  * Copyright(c) 2013 jake luer <jake@alogicalparadox.com>
@@ -20,15 +21,10 @@ try {
  * All of these attributes must be available on the global object for the current environment
  * to be considered a DOM environment (browser)
  */
-var domIndicatorAttributes = [
-  'location',
-  'document',
-  'navigator',
-  'HTMLElement',
-];
-var isDom = domIndicatorAttributes.every(function inGlobal(attr) {
-  return attr in globalObject;
-});
+var isDom = 'location' in globalObject &&
+  'document' in globalObject &&
+  'navigator' in globalObject &&
+  'HTMLElement' in globalObject;
 
 var symbolExists = typeof Symbol !== 'undefined';
 var mapExists = typeof Map !== 'undefined';

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ var promiseExists = typeof Promise === 'function';
 // See http://stackoverflow.com/a/6930376
 var globalObject = null;
 try {
-  globalObject = Function('return this')() || (0, eval)('this'); // eslint-disable-line no-new-func, no-eval
+  globalObject = new Function('return this')(); // eslint-disable-line no-new-func
 } catch (ignoredError) {
   globalObject = window; // eslint-disable-line no-undef
 }

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@
  */
 var promiseExists = typeof Promise === 'function';
 
+/* eslint-disable */
 // See http://stackoverflow.com/a/6930376
 var globalObject;
 try {
@@ -13,6 +14,7 @@ try {
 } catch (e) {
   globalObject = window;
 }
+/* eslint-enable */
 
 /*
  * All of these attributes must be available on the global object for the current environment
@@ -22,9 +24,9 @@ var domIndicatorAttributes = [
   'location',
   'document',
   'navigator',
-  'HTMLElement'
+  'HTMLElement',
 ];
-var isDom = domIndicatorAttributes.every(function(attr) {
+var isDom = domIndicatorAttributes.every(function inGlobal(attr) {
   return attr in globalObject;
 });
 

--- a/index.js
+++ b/index.js
@@ -7,22 +7,22 @@
  */
 var promiseExists = typeof Promise === 'function';
 
-// See http://stackoverflow.com/a/6930376
-var globalObject = null;
-try {
-  globalObject = new Function('return this')(); // eslint-disable-line no-new-func
-} catch (ignoredError) {
-  globalObject = window; // eslint-disable-line no-undef
-}
+/* eslint-disable no-undef */
+var isDom = false;
+var globalObject = typeof self === 'object' ? self : global; // eslint-disable-line id-blacklist
 
 /*
  * All of these attributes must be available on the global object for the current environment
  * to be considered a DOM environment (browser)
  */
-var isDom = 'location' in globalObject &&
-  'document' in globalObject &&
-  'navigator' in globalObject &&
-  'HTMLElement' in globalObject;
+if (typeof window === 'object' &&
+  'document' in window &&
+  'navigator' in window &&
+  'HTMLElement' in window
+) {
+  isDom = true;
+  globalObject = window; // eslint-disable-line no-undef
+}
 
 var symbolExists = typeof Symbol !== 'undefined';
 var mapExists = typeof Map !== 'undefined';
@@ -173,7 +173,7 @@ module.exports = function typeDetect(obj) {
      * Test: `Object.prototype.toString.call(document.createElement('blockquote'))``
      *  - IE <=10 === "[object HTMLBlockElement]"
      */
-    if (obj instanceof HTMLElement && obj.tagName === 'BLOCKQUOTE') {
+    if (obj instanceof globalObject.HTMLElement && obj.tagName === 'BLOCKQUOTE') {
       return 'HTMLQuoteElement';
     }
 
@@ -189,7 +189,7 @@ module.exports = function typeDetect(obj) {
      *  - Firefox === "[object HTMLTableCellElement]"
      *  - Safari === "[object HTMLTableCellElement]"
      */
-    if (obj instanceof HTMLElement && obj.tagName === 'TD') {
+    if (obj instanceof globalObject.HTMLElement && obj.tagName === 'TD') {
       return 'HTMLTableDataCellElement';
     }
 
@@ -205,7 +205,7 @@ module.exports = function typeDetect(obj) {
      *  - Firefox === "[object HTMLTableCellElement]"
      *  - Safari === "[object HTMLTableCellElement]"
      */
-    if (obj instanceof HTMLElement && obj.tagName === 'TH') {
+    if (obj instanceof globalObject.HTMLElement && obj.tagName === 'TH') {
       return 'HTMLTableHeaderCellElement';
     }
   }

--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ var isDom = typeof window === 'object' &&
   'document' in window &&
   'navigator' in window &&
   'HTMLElement' in window;
+/* eslint-enable */
 
 var symbolExists = typeof Symbol !== 'undefined';
 var mapExists = typeof Map !== 'undefined';

--- a/index.js
+++ b/index.js
@@ -156,7 +156,7 @@ module.exports = function typeDetect(obj) {
      * Test: `Object.prototype.toString.call(document.createElement('blockquote'))``
      *  - IE <=10 === "[object HTMLBlockElement]"
      */
-    if (obj instanceof HTMLElement && obj.tagName === 'BLOCKQUOTE') {
+    if (obj instanceof globalObject.HTMLElement && obj.tagName === 'BLOCKQUOTE') {
       return 'HTMLQuoteElement';
     }
 
@@ -172,7 +172,7 @@ module.exports = function typeDetect(obj) {
      *  - Firefox === "[object HTMLTableCellElement]"
      *  - Safari === "[object HTMLTableCellElement]"
      */
-    if (obj instanceof HTMLElement && obj.tagName === 'TD') {
+    if (obj instanceof globalObject.HTMLElement && obj.tagName === 'TD') {
       return 'HTMLTableDataCellElement';
     }
 
@@ -188,7 +188,7 @@ module.exports = function typeDetect(obj) {
      *  - Firefox === "[object HTMLTableCellElement]"
      *  - Safari === "[object HTMLTableCellElement]"
      */
-    if (obj instanceof HTMLElement && obj.tagName === 'TH') {
+    if (obj instanceof globalObject.HTMLElement && obj.tagName === 'TH') {
       return 'HTMLTableHeaderCellElement';
     }
   }


### PR DESCRIPTION
Instead uses `globalObject.HTMLElement`, to avoid breaking in a node environment where `HTMLElement` is not defined.

Closes #98