### PR TITLE
Divide 'number' typeof into further sub-categories 'NaN', 'Infinity', and 'number'.

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,6 +51,20 @@ module.exports = function typeDetect(obj) {
    *   function           x 31,296,870 ops/sec ±0.96% (83 runs sampled)
    */
   var typeofObj = typeof obj;
+  
+  if (typeofObj === 'number') {
+      if (obj !== obj) {
+          return 'NaN';
+      }
+      if (obj === Infinity) {
+          return 'Infinity';
+      }
+      if (obj === (-Infinity)) {
+          return 'Infinity';
+      }
+      return 'number';
+  }
+  
   if (typeofObj !== 'object') {
     return typeofObj;
   }


### PR DESCRIPTION
Hi,

I'd like to propose an addition to this library for the 'number' typeof.

In the standard JavaScript specification, NaN and infinity values are considered to be numbers, which means that after the typeof operator return 'number', you still need to check for these two cases.  This library has already greatly simplified my type checks for the 'object' typeof, but is not so useful when 'number' is returned as I still need to check for NaN and (-)Infinity.  Therefore I'd like to some additional checks and return values for this scenario.

In my code, I've checks for Infinity and -Infinity, but have not made a distinction between the return values as I don't see a need for it, but I've kept the checks separate in case you feel there is.  I also decided against a check for integer as there are cases where you want to accept either, and having to check for both would seem to me to violate the point of the library.  However, I don't think I've ever run across a valid use case where NaN and (-)Infinity was acceptable when all you wanted was a usable number.

I can always build a wrapper around your library and adds these checks to it, if you decide against this PR, but I think it would be convenient if this library had the check built in.  Please let me know if you think this will be worth adding.

X.