### PR TITLE
fix: favour extended array toStringTag where available

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,7 +92,10 @@ module.exports = function typeDetect(obj) {
    * Post:
    *   array literal      x 22,479,650 ops/sec ±0.96% (81 runs sampled)
    */
-  if (Array.isArray(obj)) {
+  if (
+    Array.isArray(obj) &&
+    (symbolToStringTagExists === false || typeof obj[Symbol.toStringTag] === 'undefined')
+  ) {
     return 'Array';
   }
 

--- a/test/index.js
+++ b/test/index.js
@@ -259,7 +259,6 @@ describe('Generic', function () {
       Object.prototype.toString = originalObjectToString; // eslint-disable-line no-extend-native
     });
 
-
     it('plain object', function () {
       var obj = {};
       obj[Symbol.toStringTag] = function () {

--- a/test/tostringtag-extras.js
+++ b/test/tostringtag-extras.js
@@ -1,0 +1,21 @@
+'use strict';
+
+var assert = require('simple-assert');
+var type = require('..');
+var symbolExists = typeof Symbol === 'function';
+var symbolToStringTagExists = symbolExists && typeof Symbol.toStringTag !== 'undefined';
+function describeIf(condition) {
+  return condition ? describe : describe.skip;
+}
+
+describeIf(symbolToStringTagExists)('toStringTag extras', function () {
+
+  it('supports toStringTag on arrays', function () {
+    assert(type([]) === 'Array');
+    var arr = [];
+    arr[Symbol.toStringTag] = 'foo';
+    assert(type(arr) === 'foo', 'type(arr) === "foo"');
+  });
+
+
+});


### PR DESCRIPTION
Closes #49. Supersedes #50 by adding tests. Thanks @dvlsg!