### PR TITLE
Do not call getter when checking for Symbol.toStringTag in obj

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,7 +94,7 @@ module.exports = function typeDetect(obj) {
    */
   if (
     Array.isArray(obj) &&
-    (symbolToStringTagExists === false || typeof obj[Symbol.toStringTag] === 'undefined')
+    (symbolToStringTagExists === false || !(Symbol.toStringTag in obj))
   ) {
     return 'Array';
   }


### PR DESCRIPTION
Due to the fact that I made the huge mistake of merging #95 before seeing @shvaikalesh's comment about triggering the `Symbol.toStringTag` getter in `obj` I think it was better to just fix this in a separate PR than reverting stuff and putting it back in.

I'm really sorry for this 😓 