### PR TITLE
chore(package): list all contributors

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,16 @@
   "license": "MIT",
   "author": "Jake Luer <jake@alogicalparadox.com> (http://alogicalparadox.com)",
   "contributors": [
-    "David Losert (https://github.com/davelosert)",
     "Keith Cirkel (https://github.com/keithamus)",
+    "David Losert (https://github.com/davelosert)",
+    "Aleksey Shvayka (https://github.com/shvaikalesh)",
+    "Lucas Fernandes da Costa (https://github.com/lucasfcosta)",
+    "Grant Snodgrass (https://github.com/meeber)",
+    "Jeremy Tice (https://github.com/jetpacmonkey)",
+    "Edward Betts (https://github.com/EdwardBetts)",
+    "dvlsg (https://github.com/dvlsg)",
+    "Amila Welihinda (https://github.com/amilajack)",
+    "Jake Champion (https://github.com/JakeChampion)",
     "Miroslav Bajtoš (https://github.com/bajtos)"
   ],
   "files": [


### PR DESCRIPTION
This changes the `contributors` field in the package.json for type-detect to reflect the list available at https://github.com/chaijs/type-detect/graphs/contributors. There are two notable omissions from the list: Greenkeeper Bot (which is a bot) and `locigalparadox` - who is listed in the `author` field.