### PR TITLE
chore(travis): ensure BUILD_LEADER_ID is fixed to job number

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,6 +64,7 @@ jobs:
         - if [ "$TRAVIS_PULL_REQUEST" != "false" ] || [ "$TRAVIS_BRANCH" != "master" ]; then echo "the deploy job only runs for the master branch. This build will now exit"; exit 0; fi
         - if [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_BRANCH" == "master" ]; then npm run semantic-release; fi
       env:
+       - BUILD_LEADER_ID=10
        # GH_TOKEN type-detect travis 
        - secure: "MPzfTVm7U1Q/eYhHT3DXwZki5Xn4ODNs/uXEM5PB2m+BxbytaAgU+3JSI0ZREv+JLk9CRnj2yWebaQkm+0ompkPRus0pEFuwEsMJ3HqV4ISj6zWGLPNjeJqy6kGa+m1WlkfHM+Spj7vrmk2yclZsmke4xpeQy9W8nnPDEHe6uoQ="
        # NPM_TOKEN …7f80442b


### PR DESCRIPTION
BUILD_LEADER_ID is needed for semantic-release to pick the right job that
semantic-release publishes under. The default behavior for semantic-release
is to elect a build using the latest node version (which in our case is job
9). This var fixes the job to job 10, which is the actual job we have to
run semantic-release.

This should _actually_ _really_ _properly_ fix the build now 😅 