### PR TITLE
Better check for the existence of window

### DIFF
--- a/index.js
+++ b/index.js
@@ -101,7 +101,7 @@ export default function typeDetect(obj) {
 
   // Not caching existence of `window` and related properties due to potential
   // for `window` to be unset before tests in quasi-browser environments.
-  if (typeof window === 'object') {
+  if (typeof window === 'object' && window !== null) {
     /* ! Spec Conformance
      * (https://html.spec.whatwg.org/multipage/browsers.html#location)
      * WhatWG HTML$7.7.3 - The `Location` interface


### PR DESCRIPTION
The current check for `window` doesn't cover the scenario were `window` is `null`:

https://github.com/chaijs/type-detect/blob/master/index.js#L104

Setting window to `null` bypasses the current `window` check and errors when trying to read `location` off of it.

While I would encourage users to set the `window` to `undefined` when they're resetting in tests, not everyone will.  This is a small PR to fix that.