### PR TITLE
remove xvfb pre-test step in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,6 @@ jobs:
       addons:
         chrome: stable
         firefox: latest
-      before_script:
-        - "export DISPLAY=:99.0"
-        - "sh -e /etc/init.d/xvfb start"
-        - sleep 3 # give xvfb some time to start
       script: npm run test:browser
       env:
         - QUICKLY_TEST_BROWSERS_AVAILABLE_IN_CI=1 # kept here for easier reading of build log


### PR DESCRIPTION
As far as I can tell `xvfb` is not needed when running tests in headless browsers.

From [Getting Started with Headless Chrome](https://developers.google.com/web/updates/2017/04/headless-chrome):

>So I still need Xvfb?
>
>No. Headless Chrome doesn't use a window so a display server like Xvfb is no longer needed. You can happily run your automated tests without it.
>
>What is Xvfb? Xvfb is an in-memory display server for Unix-like systems that enables you to run graphical applications (like Chrome) without an attached physical display. Many people use Xvfb to run earlier versions of Chrome to do "headless" testing.