### PR TITLE
Clarify browser usage. #139

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,10 @@ The primary export of `type-detect` is function that can serve as a replacement 
 ```js
 var type = require('type-detect');
 ```
+Or, in the browser use case, after the <script> tag,
+ ```js
+ var type = typeDetect;
+ ```
 
 #### array
 


### PR DESCRIPTION
When importing type-detect in the browser, the function is called 'typeDetect'

If the usage examples are followed as-is, the browser will throw an error indicating that type() is not defined.

In order to run the examples as written in the browser, the user should declare a variable type that refers to typeDetect(). An alternative would be to provide another set of browser-specific examples using typeDetect() instead of type(), but I think that would be overly verbose and confusing.