### PR TITLE
Readme Aesthetics

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </h1>
 <br>
 <p align=center>
-  Improved typeof detection for <a href="https://nodejs.org">node</a>, <a href="https://deno.land/">deno</a>, and the browser.
+  Improved typeof detection for <a href="https://nodejs.org">Node.js</a>, <a href="https://deno.land/">Deno</a>, and the browser.
 </p>
 
 <p align=center>

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </h1>
 <br>
 <p align=center>
-  Improved typeof detection for <a href="https://nodejs.org">node</a>, <a href="https://deno.land/">, and the browser.
+  Improved typeof detection for <a href="https://nodejs.org">node</a>, <a href="https://deno.land/">deno</a>, and the browser.
 </p>
 
 <p align=center>


### PR DESCRIPTION
- link to deno was missing the text "deno" and the closing tag
- Node became Node.js, and deno became Deno.

PS. Can you opt this repo in to hacktoberfest?